### PR TITLE
feat: add network synchronization for 1D and 2D platforms and crushers

### DIFF
--- a/assets/maps/diversity/platforms.json
+++ b/assets/maps/diversity/platforms.json
@@ -5,9 +5,7 @@
     "movingPlatforms2D": [
         {"x": 150, "y": 0, "size": 0.42, "speed": 1, "left": [400, -100], "right": [700, -170], "start": false, "texture": 0}
     ],
-    "switchingPlatforms": [
-        {"x": 20, "y": -100, "size": 0.3, "bpm": 60, "steps": [[20, -100], [120, -100], [220, -100]], "texture": 0}
-    ],
+    "switchingPlatforms": [],
     "weightPlatforms": [
         {"x": -150, "y": 15, "size": 0.25, "stepDistance": 50, "texture": 1}
     ],

--- a/include/Game/Game.h
+++ b/include/Game/Game.h
@@ -189,7 +189,8 @@ public:
      * @param last_checkpoint The last checkpoint reached.
      * @param players The list of players to load.
      */
-    void loadLevel(const std::string &map_name, short last_checkpoint, const nlohmann::json::array_t &players);
+    void loadLevel(const std::string &map_name, short last_checkpoint, const nlohmann::json::array_t &players,
+                   const nlohmann::json::array_t &movingPlatforms1D, const nlohmann::json::array_t &movingPlatforms2D, const nlohmann::json::array_t &crushers);
 
     /**
      * @brief Updates the game logic.

--- a/include/Game/Level.h
+++ b/include/Game/Level.h
@@ -160,7 +160,7 @@ public:
      * @brief Return the switchingPlatforms attribute.
      * @return A vector of SwitchingPlatform.
      */
-    [[nodiscard]] std::vector<SwitchingPlatform> getSwitchingPlatforms() const;
+    [[nodiscard]] std::vector<SwitchingPlatform>& getSwitchingPlatforms();
 
     /**
      * @brief Return the weightPlatform attribute.

--- a/include/Game/Platforms/IPlatform.h
+++ b/include/Game/Platforms/IPlatform.h
@@ -14,6 +14,12 @@
  * @brief Defines the Platform interface representing a platform.
  */
 
+
+struct PlatformBuffer {
+    float deltaX;
+    float deltaY;
+};
+
 /**
  * @interface IPlatform
  * @brief Represents a platform in a 2D game.
@@ -32,7 +38,7 @@ public:
     [[nodiscard]] virtual bool getIsMoving() const = 0;
     [[nodiscard]] virtual SDL_FRect getBoundingBox() const = 0;
 
-    // ACCESSORS
+    // MODIFIERS
     virtual void setIsMoving(bool state) = 0;
 
     // METHODS

--- a/include/Game/Platforms/MovingPlatform1D.h
+++ b/include/Game/Platforms/MovingPlatform1D.h
@@ -28,6 +28,7 @@ private:
     float size; /**< The size of the platform. */
     float speed; /**< The speed of the platform. */
     float move = 0; /**< The number of pixel the platform has moved */
+    PlatformBuffer buffer = {0, 0}; /**< The buffer of the player */
 
     const float min; /**< The minimum x-coordinate of the platform's position. */
     const float max; /**< The maximum x-coordinate of the platform's position. */
@@ -85,6 +86,12 @@ public:
     [[nodiscard]] bool getAxis() const;
 
     /**
+     * @brief Return the direction attribute.
+     * @return The value of the direction attribute.
+     */
+    [[nodiscard]] float getDirection() const;
+
+    /**
      * @brief Return the isMoving attribute.
      * @return The value of the isMoving attribute.
      */
@@ -98,6 +105,36 @@ public:
 
 
     /* MODIFIERS */
+
+    /**
+     * @brief Set the x attribute.
+     * @param value The new x-coordinate of the platform's position.
+     */
+    void setX(float value);
+
+    /**
+     * @brief Set the y attribute.
+     * @param value The new y-coordinate of the platform's position.
+     */
+    void setY(float value);
+
+    /**
+     * @brief Set the move attribute.
+     * @param value The new move of the platform.
+     */
+    void setMove(float value);
+
+    /**
+     * @brief Set the direction attribute.
+     * @param value The new direction of the platform.
+     */
+    void setDirection(float value);
+
+    /**
+    * @brief Sets the buffer attribute.
+    * @param value The new value of the buffer attribute.
+    */
+    void setBuffer(PlatformBuffer value);
 
     /**
      * @brief Set the isMoving attribute.

--- a/include/Game/Platforms/MovingPlatform2D.h
+++ b/include/Game/Platforms/MovingPlatform2D.h
@@ -27,6 +27,7 @@ private:
     float speed; /**< The speed of the platform. */
     float moveX = 0; /**< The number of pixel the platform has moved on the x-axis. */
     float moveY = 0; /**< The number of pixel the platform has moved on the y-axis. */
+    PlatformBuffer buffer = {0, 0}; /**< The buffer of the player */
 
     const Point left; /**< A Point representing the minimum position of the platform. */
     const Point right; /**< A Point representing the maximum position of the platform. */
@@ -87,6 +88,18 @@ public:
     [[nodiscard]] float getMoveY() const;
 
     /**
+     * @brief Return the directionX attribute.
+     * @return The value of the directionX attribute.
+     */
+    [[nodiscard]] float getDirectionX() const;
+
+    /**
+     * @brief Return the directionY attribute.
+     * @return The value of the directionY attribute.
+     */
+    [[nodiscard]] float getDirectionY() const;
+
+    /**
      * @brief Return the isMoving attribute.
      * @return The value of the isMoving attribute.
      */
@@ -103,6 +116,48 @@ public:
 
 
     /* MODIFIERS */
+
+    /**
+     * @brief Set the x attribute.
+     * @param value The new value of the x attribute.
+     */
+    void setX(float value);
+
+    /**
+     * @brief Set the y attribute.
+     * @param value The new value of the y attribute.
+     */
+    void setY(float value);
+
+    /**
+     * @brief Set the moveX attribute.
+     * @param value The new value of the moveX attribute.
+     */
+    void setMoveX(float value);
+
+    /**
+     * @brief Set the moveY attribute.
+     * @param value The new value of the moveY attribute.
+     */
+    void setMoveY(float value);
+
+    /**
+     * @brief Set the directionX attribute.
+     * @param value The new value of the directionX attribute.
+     */
+    void setDirectionX(float value);
+
+    /**
+     * @brief Set the directionY attribute.
+     * @param value The new value of the directionY attribute.
+     */
+    void setDirectionY(float value);
+
+    /**
+     * @brief Set the buffer attribute.
+     * @param value The new value of the buffer attribute.
+     */
+    void setBuffer(PlatformBuffer value);
 
     /**
      * @brief Set the isMoving attribute.

--- a/include/Game/Player.h
+++ b/include/Game/Player.h
@@ -382,7 +382,7 @@ public:
 
     // Equality operator for comparing two players
     bool operator==(const Player &other) const {
-        return (x == other.x && y == other.y && width == other.width && height == other.height);
+        return (playerID == other.playerID);
     }
 
 

--- a/include/Game/Traps/Crusher.h
+++ b/include/Game/Traps/Crusher.h
@@ -5,6 +5,10 @@
 #include "../Point.h"
 #include "../../Sounds/SoundEffect.h"
 
+struct CrusherBuffer {
+    float deltaX;
+    float deltaY;
+};
 
 class Crusher {
 private:
@@ -21,6 +25,7 @@ private:
     float direction = 1; /**< The direction of the crusher's movement. */
     bool isCrushing = false; /**< Flag indicating if the crusher is currently crushing. */
     bool isMoving = true; /** Flag indicating if the crusher is currently moving. */
+    CrusherBuffer buffer = {0, 0}; /**< The buffer of the crusher */
 
     // TIME ATTRIBUTES
     int timer = 0; /**< The timer of the crusher. */
@@ -68,6 +73,12 @@ public:
     [[nodiscard]] float getH() const;
 
     /**
+     * @brief Return the direction attribute.
+     * @return The value of the direction attribute.
+     */
+    [[nodiscard]] float getDirection() const;
+
+    /**
      * @brief Return the isCrushing attribute.
      * @return The value of the isCrushing attribute.
      */
@@ -93,6 +104,30 @@ public:
 
 
     /* MODIFIERS */
+
+    /**
+     * @brief Set the x attribute.
+     * @param value The new value of the x attribute.
+     */
+    void setX(float value);
+
+    /**
+     * @brief Set the y attribute.
+     * @param value The new value of the y attribute.
+     */
+    void setY(float value);
+
+    /**
+     * @brief Set the direction attribute.
+     * @param value The new value of the direction attribute.
+     */
+    void setDirection(float value);
+
+    /**
+     * @brief Set the buffer attribute.
+     * @param value The new value of the buffer attribute.
+     */
+    void setBuffer(CrusherBuffer value);
 
     /**
      * @brief Set the isMoving attribute.

--- a/src/Game/GameManagers/BroadPhaseManager.cpp
+++ b/src/Game/GameManagers/BroadPhaseManager.cpp
@@ -171,7 +171,7 @@ void BroadPhaseManager::checkSwitchingPlatforms(const SDL_FRect &broad_phase_are
     switchingPlatforms.clear(); // Empty old switching platforms
 
     // Check for collisions with each switching platform
-    for (const SwitchingPlatform &platform: gamePtr->getLevel()->getSwitchingPlatforms()) {
+    for (SwitchingPlatform const &platform: gamePtr->getLevel()->getSwitchingPlatforms()) {
         if (checkAABBCollision(broad_phase_area, platform.getBoundingBox())) {
             switchingPlatforms.push_back(platform);
         }

--- a/src/Game/GameManagers/PlayerManager.cpp
+++ b/src/Game/GameManagers/PlayerManager.cpp
@@ -68,7 +68,7 @@ void PlayerManager::removePlayer(const Player &player) {
 
 void PlayerManager::killPlayer(Player &player) {
     player.increaseDeathCount();
-    removePlayer(player);
+    std::erase(alivePlayers, player);
     deadPlayers.emplace_back(player);
 }
 

--- a/src/Game/Level.cpp
+++ b/src/Game/Level.cpp
@@ -84,7 +84,7 @@ std::vector<MovingPlatform2D>& Level::getMovingPlatforms2D() {
     return movingPlatforms2D;
 }
 
-std::vector<SwitchingPlatform> Level::getSwitchingPlatforms() const {
+std::vector<SwitchingPlatform>& Level::getSwitchingPlatforms() {
     return switchingPlatforms;
 }
 

--- a/src/Game/Platforms/MovingPlatform1D.cpp
+++ b/src/Game/Platforms/MovingPlatform1D.cpp
@@ -55,6 +55,10 @@ bool MovingPlatform1D::getAxis() const {
     return axis;
 }
 
+float MovingPlatform1D::getDirection() const {
+    return direction;
+}
+
 bool MovingPlatform1D::getIsMoving() const {
     return isMoving;
 }
@@ -65,6 +69,26 @@ SDL_FRect MovingPlatform1D::getBoundingBox() const {
 
 
 /* MODIFIERS */
+
+void MovingPlatform1D::setX(float value) {
+    x = value;
+}
+
+void MovingPlatform1D::setY(float value) {
+    y = value;
+}
+
+void MovingPlatform1D::setMove(float value) {
+    move = value;
+}
+
+void MovingPlatform1D::setDirection(float value) {
+    direction = value;
+}
+
+void MovingPlatform1D::setBuffer(PlatformBuffer val) {
+    buffer = val;
+}
 
 void MovingPlatform1D::setIsMoving(bool state) {
     isMoving = state;
@@ -79,7 +103,19 @@ void MovingPlatform1D::applyXaxisMovement(double delta_time) {
     move *= speed; // Apply speed
     move *= direction; // Apply direction
 
-    x += move; // Apply movement
+    if (buffer.deltaX > 40 || buffer.deltaX < -40) {
+        x = x + buffer.deltaX;
+        buffer.deltaX = 0;
+    }
+
+    else {
+        // Add a part of the buffer to the player's position
+        float bufferFraction = static_cast<float>(delta_time) * 1000.0f / 50.0f;
+        x += move + bufferFraction * buffer.deltaX;
+
+        // Decrease the buffer
+        buffer.deltaX -= bufferFraction * buffer.deltaX;
+    }
 
     // If the platform has reached its minimum
     if (x < min) {
@@ -100,7 +136,19 @@ void MovingPlatform1D::applyYaxisMovement(double delta_time) {
     move *= speed; // Apply speed
     move *= direction; // Apply direction
 
-    y += move; // Apply movement
+    if (buffer.deltaY > 40 || buffer.deltaY < -40) {
+        y += buffer.deltaY;
+        buffer.deltaY = 0;
+    }
+
+    else {
+        // Add a part of the buffer to the player's position
+        float bufferFraction = static_cast<float>(delta_time) * 1000.0f / 50.0f;
+        y += move + bufferFraction * buffer.deltaY;
+
+        // Decrease the buffer
+        buffer.deltaY -= bufferFraction * buffer.deltaY;
+    }
 
     // If the platform has reached its minimum, change direction to left
     if (y < min) {

--- a/src/Game/Platforms/MovingPlatform2D.cpp
+++ b/src/Game/Platforms/MovingPlatform2D.cpp
@@ -61,6 +61,14 @@ float MovingPlatform2D::getMoveY() const {
     return moveY;
 }
 
+float MovingPlatform2D::getDirectionX() const {
+    return directionX;
+}
+
+float MovingPlatform2D::getDirectionY() const {
+    return directionY;
+}
+
 bool MovingPlatform2D::getIsMoving() const {
     return isMoving;
 }
@@ -71,6 +79,34 @@ SDL_FRect MovingPlatform2D::getBoundingBox() const {
 
 
 /* MODIFIERS */
+
+void MovingPlatform2D::setX(float value) {
+    x = value;
+}
+
+void MovingPlatform2D::setY(float value) {
+    y = value;
+}
+
+void MovingPlatform2D::setMoveX(float value) {
+    moveX = value;
+}
+
+void MovingPlatform2D::setMoveY(float value) {
+    moveY = value;
+}
+
+void MovingPlatform2D::setDirectionX(float value) {
+    directionX = value;
+}
+
+void MovingPlatform2D::setDirectionY(float value) {
+    directionY = value;
+}
+
+void MovingPlatform2D::setBuffer(PlatformBuffer value) {
+    buffer = value;
+}
 
 void MovingPlatform2D::setIsMoving(bool state) {
     isMoving = state;
@@ -90,17 +126,36 @@ void MovingPlatform2D::applyMovement(double delta_time) {
         moveX *= speed; // Apply speed
         moveX *= directionX; // Apply direction
 
-        // Calculate y-axis movement
-        moveY *= static_cast<float>(delta_time); // Apply movement per second
-        moveY *= speed; // Apply speed
-        moveY *= directionY; // Apply direction
+        // If the buffer is too big, move the platform and reset the buffer
+        if (buffer.deltaX > 40 || buffer.deltaX < -40 || buffer.deltaY > 40 || buffer.deltaY < -40) {
+            x = x + buffer.deltaX;
+            y = y + buffer.deltaY;
 
-        // Apply ratio
-        ratio > 1 ? moveY /= ratio : moveX *= ratio;
+            buffer.deltaX = 0;
+            buffer.deltaY = 0;
+        }
 
-        // Apply movement to the platform
-        x += moveX;
-        y += moveY;
+        else {
+            // Calculate y-axis movement
+            moveY *= static_cast<float>(delta_time); // Apply movement per second
+            moveY *= speed; // Apply speed
+            moveY *= directionY; // Apply direction
+
+            // Apply ratio
+            ratio > 1 ? moveY /= ratio : moveX *= ratio;
+
+
+            // Add a part of the buffer to the platform's position
+            float bufferFraction = static_cast<float>(delta_time) * 1000.0f / 50.0f;
+
+            // Apply movement to the platform
+            x += moveX + bufferFraction * buffer.deltaX;
+            y += moveY + bufferFraction * buffer.deltaY;
+
+            // Decrease the buffer
+            buffer.deltaX -= bufferFraction * buffer.deltaX;
+            buffer.deltaY -= bufferFraction * buffer.deltaY;
+        }
 
         // If the platform has reached its minimum point
         if (x < left.x) {

--- a/src/Game/Traps/Crusher.cpp
+++ b/src/Game/Traps/Crusher.cpp
@@ -31,6 +31,10 @@ float Crusher::getH() const {
     return h;
 }
 
+float Crusher::getDirection() const {
+    return direction;
+}
+
 bool Crusher::getIsCrushing() const {
     return isCrushing;
 }
@@ -50,6 +54,22 @@ SDL_FRect Crusher::getCrushingZoneBoundingBox() const {
 
 /* MODIFIERS */
 
+void Crusher::setX(float value) {
+    x = value;
+}
+
+void Crusher::setY(float value) {
+    y = value;
+}
+
+void Crusher::setDirection(float value) {
+    direction = value;
+}
+
+void Crusher::setBuffer(CrusherBuffer value) {
+    buffer = value;
+}
+
 void Crusher::setIsMoving(bool state) {
     isMoving = state;
     if (!state) {
@@ -66,6 +86,11 @@ void Crusher::applyUpMovement(double delta_time) {
     float normal_movement = pixelToMove * static_cast<float>(delta_time);
     y -= std::min(smooth_movement, normal_movement);
 
+    // Apply a part of the buffer and decrease it accordingly
+    float bufferFraction = static_cast<float>(delta_time) * 1000.0f / 50.0f;
+    y+= bufferFraction * buffer.deltaY;
+    buffer.deltaY -= bufferFraction * buffer.deltaY;
+
     // The movement is finished
     if (y <= min) {
         y = min;
@@ -78,6 +103,11 @@ void Crusher::applyUpMovement(double delta_time) {
 bool Crusher::applyDownMovement(double delta_time) {
     auto blend = static_cast<float>(1 - std::pow(0.5F, delta_time * 10));
     y += (y - min + 0.1F) * blend;
+
+    // Apply a part of the buffer and decrease it accordingly
+    float bufferFraction = static_cast<float>(delta_time) * 1000.0f / 50.0f;
+    y += bufferFraction * buffer.deltaY;
+    buffer.deltaY -= bufferFraction * buffer.deltaY;
 
     // The crusher can kill only if he reached the half of his down movement
     if (y - min > (max - min) / 2) isCrushing = true;

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -136,7 +136,14 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char *args[]) {
 
             if (mainMessage == "InitializeClientGame") {
                 nlohmann::json message = nlohmann::json::parse(parameters[0]);
-                game.loadLevel(message["mapName"], message["lastCheckpoint"], message["players"]);
+                game.loadLevel(
+                        message["mapName"],
+                        message["lastCheckpoint"],
+                        message["players"],
+                        message["platforms1D"],
+                        message["platforms2D"],
+                        message["crushers"]
+                );
             }
         }
 


### PR DESCRIPTION
This commit introduces network synchronization for 1D and 2D platforms as well as crushers. There is dual synchronization: when a player joins a game, these elements are adjusted with server positions, and every 50 milliseconds, their position is corrected using interpolation similar to the player.